### PR TITLE
New step logic

### DIFF
--- a/pommerman/agents/simple_agent.py
+++ b/pommerman/agents/simple_agent.py
@@ -25,7 +25,6 @@ class SimpleAgent(BaseAgent):
         self._prev_direction = None
 
     def act(self, obs, action_space):
-
         def convert_bombs(bomb_map):
             ret = []
             locations = np.where(bomb_map > 0)

--- a/pommerman/utility.py
+++ b/pommerman/utility.py
@@ -232,12 +232,21 @@ def position_is_powerup(board, position):
     return board[position] in item_values
 
 
+def position_is_wall(board, position):
+    return position_is_rigid(board, position) or \
+        position_is_wood(board, position)
+
+
 def position_is_passage(board, position):
     return _position_is_item(board, position, constants.Item.Passage)
 
 
 def position_is_rigid(board, position):
     return _position_is_item(board, position, constants.Item.Rigid)
+
+
+def position_is_wood(board, position):
+    return _position_is_item(board, position, constants.Item.Wood)
 
 
 def position_is_agent(board, position):


### PR DESCRIPTION
New agent and bomb movement logic.

Add seconday bomb explosions and restore explode on fire functionality.
Kill agents that walk into fire.

forward_model: some style fixes and comments, plus a change to get_info to fix that it wasn't returning correctly when all living agents died on a single turn.